### PR TITLE
Remove outdated download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Lens Extensions
 
-> **IMPORTANT:** The use of Lens extensions are subject to their own licenses. Lens open source project and its contributors do not provide any maintenance, guarantees or warranties for any extensions listed in here. They may contain bugs, errors or other unwanted features. Use at your own risk. 
+> **IMPORTANT:** The use of Lens extensions are subject to their own licenses. Lens open source project and its contributors do not provide any maintenance, guarantees or warranties for any extensions listed in here. They may contain bugs, errors or other unwanted features. Use at your own risk.
 
 You'll find list of publicly available [Lens](https://k8slens.dev) extensions in here.
 
-* [Mirantis Container Cloud](https://github.com/Mirantis/lens-extension-cc/) by [Mirantis](https://mirantis.com) [[download](https://registry.npmjs.org/@mirantis/lens-extension-cc/-/lens-extension-cc-1.0.3.tgz)]
-* [Starboard](https://github.com/aquasecurity/starboard-lens-extension) by [Aqua Security](https://www.aquasec.com/) [[download](https://github.com/aquasecurity/starboard-lens-extension/releases/download/v0.0.1-alpha.1/starboard-lens-extension-0.0.1-alpha.1.tgz)]
+- [Mirantis Container Cloud](https://github.com/Mirantis/lens-extension-cc/) by [Mirantis](https://mirantis.com)
+- [Starboard](https://github.com/aquasecurity/starboard-lens-extension) by [Aqua Security](https://www.aquasec.com/) [[download](https://github.com/aquasecurity/starboard-lens-extension/releases/download/v0.0.1-alpha.1/starboard-lens-extension-0.0.1-alpha.1.tgz)]
 
 If you'd like to add / update your extension on the list above, please make a pull request!


### PR DESCRIPTION
The direct-download link will always get outdated. I'd prefer not to have to remember to keep coming here every time I publish an update. My extension's README has the necessary installation instructions how to always download the latest version from NPM.