### PR TITLE
Add NetworkPolicy viewer to community extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ You'll find list of publicly available [Lens](https://k8slens.dev) extensions in
 
 - [Certificate info](https://github.com/jkroepke/lens-extension-certificate-info) - Get information about certificates inside secret like expiry date inside lens.
 - [App Viewer](https://github.com/kocyigitkim/lens-app-viewer) - An extension for access services on Lens Ide easily.
+- [NetworkPolicy viewer](https://github.com/artturik/lens-extension-network-policy-viewer) - View your NetworkPolicy manifests as visual graph.
 
 ## Experimental & Fun & Demos
 


### PR DESCRIPTION
Using this extension you can view your NetworkPolicy as visual graph. 

<img width="767" alt="screenshot" src="https://user-images.githubusercontent.com/8836773/160256928-0fc5770e-f8c9-4bc6-b1f5-f843aae5db4f.png">

Lens v5 compatible.